### PR TITLE
Update DTH Sign in page

### DIFF
--- a/app/views/ur-r4/dth/sign-in.html
+++ b/app/views/ur-r4/dth/sign-in.html
@@ -44,13 +44,6 @@
 
                   </form>
 
-        <p>
-            <a href="./register/start">
-                Register now
-            </a>
-            if you have not used this service before.
-        </p>
-
         <h2 class="govuk-heading-m">
             Problems signing in
         </h2>


### PR DESCRIPTION
Removed the 'Register now' text link under the button.